### PR TITLE
Update README to document metric outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ If you would like to rebuild the synthetic grading dataset, run:
 python generate_grading_dataset.py
 ```
 
-This writes `data/toy_grading_dataset.csv` and prints a small summary in the
-terminal. The accuracy computation step only needs the CSV, so you can skip this
-if the dataset already exists.
+This writes `data/toy_grading_dataset.csv`, prints a small summary in the
+terminal, and removes the legacy confusion-matrix images if they are present.
+The CSV includes three derived columns (`*_GNP`) that collapse the detailed
+labels into the aggregated G/N/P buckets used later in the workflow. The
+accuracy computation step only needs the CSV, so you can skip this if the
+dataset already exists.
 
 ## 2. Compute accuracy metrics with pandas
 
@@ -36,44 +39,97 @@ python metrics/compute_accuracy.py \
   --revision-output public/revision.json
 ```
 
-The script validates the dataset columns, normalizes label text, and reports
-both overall and per-prompt accuracy. `accuracy.json` looks similar to:
+The script validates the required columns (`Prompt_ID`, `Human_Grade`,
+`Auto_Grade`, `Ground_Truth`), normalizes label text, and recreates the
+G/N/P-derived columns if they are missing. It then computes metrics for each
+supported grading scale—the detailed four-point scale and the aggregated
+G/N/P view. The resulting `accuracy.json` surfaces the default scale at the top
+level while also keeping the per-scale metrics:
 
 ```json
 {
+  "default_scale": "four_level",
+  "scale_labels": {
+    "four_level": "4-Point Detail",
+    "gnp": "G / N / P"
+  },
   "summary": {
-    "total_records": 3000,
-    "autograder_accuracy": 0.752,
-    "human_accuracy": 0.7573
+    "total_evaluations": 3000,
+    "unique_prompts": 1000,
+    "autograder_accuracy": 0.75,
+    "autograder_evaluations": 1000,
+    "human_accuracy": 0.76,
+    "human_evaluations": 3000
   },
   "per_prompt": [
     {
       "prompt_id": "PROMPT_0001",
       "count": 3,
-      "autograder_accuracy": 0.6667,
-      "human_accuracy": 1.0
+      "autograder_accuracy": 0.0,
+      "human_accuracy": 0.6667
     }
-  ]
+  ],
+  "scales": {
+    "four_level": { "summary": { ... }, "per_prompt": [ ... ] },
+    "gnp": { "summary": { ... }, "per_prompt": [ ... ] }
+  }
 }
 ```
 
 Revision-specific metrics are written to a sibling `revision.json`, which adds
-precision and recall perspectives to the revision mix:
+precision/recall details plus case breakdowns for every supported scale:
 
 ```json
 {
+  "default_scale": "four_level",
+  "scale_labels": {
+    "four_level": "4-Point Detail",
+    "gnp": "G / N / P"
+  },
   "overall": {
+    "total_evaluations": 3000,
     "revision_count": 1217,
     "revision_rate": 0.4057,
+    "correct_revision_count": 562,
     "correct_revision_precision": 0.4618,
-    "autograder_wrong_recall": 0.7493
+    "autograder_wrong_total": 750,
+    "corrected_autograder_wrong": 562,
+    "autograder_wrong_recall": 0.7493,
+    "mistake_repetition_factor": 3
   },
   "cases": {
     "autograder_wrong_human_correct": {
       "count": 562,
       "share_of_revisions": 0.4618,
+      "share_of_total": 0.1873,
       "share_of_autograder_wrong": 0.7493
+    },
+    "autograder_correct_human_wrong": {
+      "count": 532,
+      "share_of_revisions": 0.4371,
+      "share_of_total": 0.1773,
+      "share_of_autograder_wrong": null
+    },
+    "both_wrong": {
+      "count": 123,
+      "share_of_revisions": 0.1011,
+      "share_of_total": 0.041,
+      "share_of_autograder_wrong": 0.164
     }
+  },
+  "autograder_wrong_breakdown": {
+    "corrected": { "count": 562, ... },
+    "not_revised": { "count": 65, ... },
+    "revised_but_wrong": { "count": 123, ... }
+  },
+  "breakdowns": {
+    "ground_truth": [ { "label": "highly satisfying", ... } ],
+    "autograder_label": [ ... ],
+    "human_label": [ ... ]
+  },
+  "scales": {
+    "four_level": { ... },
+    "gnp": { ... }
   }
 }
 ```
@@ -84,9 +140,10 @@ Re-run the command whenever the dataset changes to keep both JSON files current.
 
 Open `public/index.html` in a browser. The page fetches `accuracy.json` and
 `revision.json` from the same directory, then renders the headline metrics,
-revision precision/recall insights, and the prompt-level table. No build step or
-framework is required—host the `public/` directory anywhere that serves static
-files.
+revision precision/recall insights, and the prompt-level table. Scale-aware
+controls let you view the detailed four-level results or the aggregated G/N/P
+perspective that the metrics script exports. No build step or framework is
+required—host the `public/` directory anywhere that serves static files.
 
 ## Repository layout
 


### PR DESCRIPTION
## Summary
- document the dataset generator's derived G/N/P columns and cleanup behaviour
- refresh the accuracy metrics example to show the multi-scale output structure
- expand the revision metrics example and note the dashboard's scale-aware controls

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d0defce528832894573e245c0acfc1