### PR TITLE
Refactor compute_accuracy helpers for readability

### DIFF
--- a/metrics/compute_accuracy.py
+++ b/metrics/compute_accuracy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -48,6 +49,15 @@ LABEL_COLUMNS = {
     for config in SCALE_CONFIGS.values()
     for column in config["columns"].values()
 }
+
+
+@dataclass(frozen=True)
+class ScaleColumns:
+    """Convenience container for the expected columns of a grading scale."""
+
+    ground_truth: str
+    autograder: str
+    human: str
 
 
 def _normalize(series: pd.Series) -> pd.Series:
@@ -119,6 +129,26 @@ def _safe_mean(series: pd.Series) -> float | None:
     return None if pd.isna(value) else float(value)
 
 
+def _resolve_scale_columns(
+    df: pd.DataFrame, config: Dict[str, Dict[str, str]]
+) -> ScaleColumns | None:
+    """Return the configured column names if all are present in ``df``."""
+
+    columns = config.get("columns", {})
+    ground_truth = columns.get("ground_truth")
+    autograder = columns.get("autograder")
+    human = columns.get("human")
+
+    if not all([ground_truth, autograder, human]):
+        return None
+    if not all(name in df.columns for name in (ground_truth, autograder, human)):
+        return None
+
+    return ScaleColumns(
+        ground_truth=ground_truth, autograder=autograder, human=human
+    )
+
+
 def _build_display_map(series: pd.Series) -> Dict[str, str]:
     """Map normalized label values back to their display text."""
 
@@ -139,19 +169,14 @@ def _build_display_map(series: pd.Series) -> Dict[str, str]:
 def _compute_accuracy_for_scale(
     normalized: pd.DataFrame, config: Dict[str, Dict[str, str]]
 ) -> Dict[str, object]:
-    columns = config.get("columns", {})
-    autograder_column = columns.get("autograder")
-    human_column = columns.get("human")
-    ground_truth_column = columns.get("ground_truth")
-
-    if not all(
-        column in normalized.columns
-        for column in (autograder_column, human_column, ground_truth_column)
-    ):
+    columns = _resolve_scale_columns(normalized, config)
+    if not columns:
         return {"summary": {}, "per_prompt": []}
 
-    autograder_matches = normalized[autograder_column] == normalized[ground_truth_column]
-    human_matches = normalized[human_column] == normalized[ground_truth_column]
+    autograder_matches = (
+        normalized[columns.autograder] == normalized[columns.ground_truth]
+    )
+    human_matches = normalized[columns.human] == normalized[columns.ground_truth]
 
     total_evaluations = int(len(normalized))
     if "Prompt_ID" in normalized.columns:
@@ -161,8 +186,8 @@ def _compute_accuracy_for_scale(
 
     if "Prompt_ID" in normalized.columns and unique_prompts:
         prompt_groups = normalized.groupby("Prompt_ID", sort=False)
-        prompt_autograder = prompt_groups[autograder_column].first()
-        prompt_ground_truth = prompt_groups[ground_truth_column].first()
+        prompt_autograder = prompt_groups[columns.autograder].first()
+        prompt_ground_truth = prompt_groups[columns.ground_truth].first()
         autograder_accuracy_value = _safe_mean(prompt_autograder == prompt_ground_truth)
     else:
         autograder_accuracy_value = _safe_mean(autograder_matches)
@@ -180,9 +205,11 @@ def _compute_accuracy_for_scale(
     if "Prompt_ID" in normalized.columns:
         for prompt_id, group in normalized.groupby("Prompt_ID", sort=True):
             prompt_autograder = _safe_mean(
-                group[autograder_column] == group[ground_truth_column]
+                group[columns.autograder] == group[columns.ground_truth]
             )
-            prompt_human = _safe_mean(group[human_column] == group[ground_truth_column])
+            prompt_human = _safe_mean(
+                group[columns.human] == group[columns.ground_truth]
+            )
             per_prompt.append(
                 {
                     "prompt_id": str(prompt_id),
@@ -249,6 +276,184 @@ def compute_metrics(df: pd.DataFrame) -> Tuple[Dict[str, object], Dict[str, obje
     return accuracy_metrics, revision_metrics
 
 
+def _build_case_masks(
+    *,
+    autograder_matches: pd.Series,
+    human_matches: pd.Series,
+    revisions: pd.Series,
+) -> Dict[str, pd.Series]:
+    """Return boolean masks describing the different revision scenarios."""
+
+    autograder_wrong = ~autograder_matches
+    human_wrong = ~human_matches
+
+    return {
+        "autograder_wrong_human_correct": autograder_wrong & human_matches & revisions,
+        "autograder_correct_human_wrong": autograder_matches & human_wrong & revisions,
+        "both_wrong": autograder_wrong & human_wrong & revisions,
+    }
+
+
+def _case_stats(
+    count: int,
+    *,
+    revision_count: int,
+    total_evaluations: int,
+    autograder_wrong_total: int,
+    include_autograder_share: bool,
+) -> Dict[str, object]:
+    """Format the aggregate metrics for a single revision case."""
+
+    entry = {
+        "count": count,
+        "share_of_revisions": _format_rate(count, revision_count),
+        "share_of_total": _format_rate(count, total_evaluations),
+    }
+    if include_autograder_share:
+        entry["share_of_autograder_wrong"] = _format_rate(
+            count, autograder_wrong_total
+        )
+    else:
+        entry["share_of_autograder_wrong"] = None
+    return entry
+
+
+def _breakdown_stats(
+    count: int,
+    *,
+    total_evaluations: int,
+    autograder_wrong_total: int,
+) -> Dict[str, object]:
+    """Format the breakdown metrics for autograder mistakes."""
+
+    return {
+        "count": count,
+        "share_of_autograder_wrong": _format_rate(count, autograder_wrong_total),
+        "share_of_total": _format_rate(count, total_evaluations),
+    }
+
+
+def _resolve_display_label(
+    column: str, value: object, display_maps: Dict[str, Dict[str, str]]
+) -> str:
+    """Return a human-readable label for ``value`` in ``column``."""
+
+    mapping = display_maps.get(column, {})
+    if isinstance(value, str):
+        return mapping.get(value, value.title())
+    return mapping.get(value, str(value))
+
+
+def _dimension_breakdowns(
+    *,
+    normalized: pd.DataFrame,
+    column_name: str,
+    dimension_key: str,
+    display_maps: Dict[str, Dict[str, str]],
+    case_masks: Dict[str, pd.Series],
+    revisions: pd.Series,
+    autograder_wrong_mask: pd.Series,
+    total_evaluations: int,
+) -> List[Dict[str, object]]:
+    """Build revision breakdowns for a single dimension such as ground truth."""
+
+    entries: List[Dict[str, object]] = []
+
+    for label, group in normalized.groupby(column_name, sort=True):
+        if pd.isna(label):
+            continue
+
+        label_total = int(len(group))
+        if label_total == 0:
+            continue
+
+        indices = group.index
+        label_revision_count = int(revisions.loc[indices].sum())
+        label_case_counts = {
+            case: int(mask.loc[indices].sum()) for case, mask in case_masks.items()
+        }
+        label_autograder_wrong_total = int(autograder_wrong_mask.loc[indices].sum())
+        label_corrected = label_case_counts.get("autograder_wrong_human_correct", 0)
+        label_both_wrong = label_case_counts.get("both_wrong", 0)
+        label_autograder_wrong_revised = label_corrected + label_both_wrong
+        label_autograder_wrong_unrevised = max(
+            0, label_autograder_wrong_total - label_autograder_wrong_revised
+        )
+
+        display_label = _resolve_display_label(column_name, label, display_maps)
+
+        entry = {
+            "total_evaluations": label_total,
+            "revision_count": label_revision_count,
+            "revision_rate": _format_rate(label_revision_count, label_total),
+            "correct_revision_count": label_corrected,
+            "correct_revision_precision": _format_rate(
+                label_corrected, label_revision_count
+            ),
+            "autograder_wrong_total": label_autograder_wrong_total,
+            "corrected_autograder_wrong": label_corrected,
+            "autograder_wrong_recall": _format_rate(
+                label_corrected, label_autograder_wrong_total
+            ),
+            "cases": {
+                "autograder_wrong_human_correct": _case_stats(
+                    label_case_counts.get("autograder_wrong_human_correct", 0),
+                    revision_count=label_revision_count,
+                    total_evaluations=label_total,
+                    autograder_wrong_total=label_autograder_wrong_total,
+                    include_autograder_share=True,
+                ),
+                "autograder_correct_human_wrong": _case_stats(
+                    label_case_counts.get("autograder_correct_human_wrong", 0),
+                    revision_count=label_revision_count,
+                    total_evaluations=label_total,
+                    autograder_wrong_total=label_autograder_wrong_total,
+                    include_autograder_share=False,
+                ),
+                "both_wrong": _case_stats(
+                    label_case_counts.get("both_wrong", 0),
+                    revision_count=label_revision_count,
+                    total_evaluations=label_total,
+                    autograder_wrong_total=label_autograder_wrong_total,
+                    include_autograder_share=True,
+                ),
+            },
+            "autograder_wrong_breakdown": {
+                "corrected": _breakdown_stats(
+                    label_corrected,
+                    total_evaluations=label_total,
+                    autograder_wrong_total=label_autograder_wrong_total,
+                ),
+                "not_revised": _breakdown_stats(
+                    label_autograder_wrong_unrevised,
+                    total_evaluations=label_total,
+                    autograder_wrong_total=label_autograder_wrong_total,
+                ),
+                "revised_but_wrong": _breakdown_stats(
+                    label_both_wrong,
+                    total_evaluations=label_total,
+                    autograder_wrong_total=label_autograder_wrong_total,
+                ),
+            },
+            "label": label,
+            "label_display": display_label,
+        }
+
+        if dimension_key == "ground_truth":
+            entry["ground_truth"] = label
+            entry["ground_truth_display"] = display_label
+        elif dimension_key == "autograder_label":
+            entry["autograder_label"] = label
+            entry["autograder_label_display"] = display_label
+        elif dimension_key == "human_label":
+            entry["human_label"] = label
+            entry["human_label_display"] = display_label
+
+        entries.append(entry)
+
+    return entries
+
+
 def _compute_revision_metrics_for_scale(
     *,
     normalized: pd.DataFrame,
@@ -257,13 +462,8 @@ def _compute_revision_metrics_for_scale(
 ) -> Dict[str, object]:
     """Compute revision-focused metrics for a single grading scale."""
 
-    columns = config.get("columns", {})
-    autograder_column = columns.get("autograder")
-    human_column = columns.get("human")
-    ground_truth_column = columns.get("ground_truth")
-
-    required_columns = [autograder_column, human_column, ground_truth_column]
-    if not all(column in normalized.columns for column in required_columns):
+    columns = _resolve_scale_columns(normalized, config)
+    if not columns:
         return {
             "overall": {},
             "cases": {},
@@ -271,18 +471,20 @@ def _compute_revision_metrics_for_scale(
             "breakdowns": {},
         }
 
-    autograder_matches = normalized[autograder_column] == normalized[ground_truth_column]
-    human_matches = normalized[human_column] == normalized[ground_truth_column]
-    revisions = normalized[human_column] != normalized[autograder_column]
+    autograder_matches = (
+        normalized[columns.autograder] == normalized[columns.ground_truth]
+    )
+    human_matches = normalized[columns.human] == normalized[columns.ground_truth]
+    revisions = normalized[columns.human] != normalized[columns.autograder]
 
     total_evaluations = int(len(normalized))
     autograder_wrong_mask = ~autograder_matches
 
-    case_masks = {
-        "autograder_wrong_human_correct": autograder_wrong_mask & human_matches & revisions,
-        "autograder_correct_human_wrong": autograder_matches & (~human_matches) & revisions,
-        "both_wrong": autograder_wrong_mask & (~human_matches) & revisions,
-    }
+    case_masks = _build_case_masks(
+        autograder_matches=autograder_matches,
+        human_matches=human_matches,
+        revisions=revisions,
+    )
 
     case_counts = {case: int(mask.sum()) for case, mask in case_masks.items()}
     revision_count = int(revisions.sum())
@@ -291,25 +493,6 @@ def _compute_revision_metrics_for_scale(
     both_wrong_count = case_counts.get("both_wrong", 0)
     autograder_wrong_revised = corrected_revision_count + both_wrong_count
     autograder_wrong_unrevised = max(0, autograder_wrong_total - autograder_wrong_revised)
-
-    def _case_entry(count: int, *, include_autograder_share: bool) -> Dict[str, object]:
-        entry = {
-            "count": count,
-            "share_of_revisions": _format_rate(count, revision_count),
-            "share_of_total": _format_rate(count, total_evaluations),
-        }
-        if include_autograder_share:
-            entry["share_of_autograder_wrong"] = _format_rate(count, autograder_wrong_total)
-        else:
-            entry["share_of_autograder_wrong"] = None
-        return entry
-
-    def _breakdown_entry(count: int) -> Dict[str, object]:
-        return {
-            "count": count,
-            "share_of_autograder_wrong": _format_rate(count, autograder_wrong_total),
-            "share_of_total": _format_rate(count, total_evaluations),
-        }
 
     unique_repetitions = 1
     if "Repetition" in normalized.columns:
@@ -334,140 +517,67 @@ def _compute_revision_metrics_for_scale(
             "mistake_repetition_factor": unique_repetitions,
         },
         "cases": {
-            "autograder_wrong_human_correct": _case_entry(
+            "autograder_wrong_human_correct": _case_stats(
                 case_counts.get("autograder_wrong_human_correct", 0),
+                revision_count=revision_count,
+                total_evaluations=total_evaluations,
+                autograder_wrong_total=autograder_wrong_total,
                 include_autograder_share=True,
             ),
-            "autograder_correct_human_wrong": _case_entry(
+            "autograder_correct_human_wrong": _case_stats(
                 case_counts.get("autograder_correct_human_wrong", 0),
+                revision_count=revision_count,
+                total_evaluations=total_evaluations,
+                autograder_wrong_total=autograder_wrong_total,
                 include_autograder_share=False,
             ),
-            "both_wrong": _case_entry(
-                case_counts.get("both_wrong", 0), include_autograder_share=True
+            "both_wrong": _case_stats(
+                case_counts.get("both_wrong", 0),
+                revision_count=revision_count,
+                total_evaluations=total_evaluations,
+                autograder_wrong_total=autograder_wrong_total,
+                include_autograder_share=True,
             ),
         },
         "autograder_wrong_breakdown": {
-            "corrected": _breakdown_entry(corrected_revision_count),
-            "not_revised": _breakdown_entry(autograder_wrong_unrevised),
-            "revised_but_wrong": _breakdown_entry(both_wrong_count),
+            "corrected": _breakdown_stats(
+                corrected_revision_count,
+                total_evaluations=total_evaluations,
+                autograder_wrong_total=autograder_wrong_total,
+            ),
+            "not_revised": _breakdown_stats(
+                autograder_wrong_unrevised,
+                total_evaluations=total_evaluations,
+                autograder_wrong_total=autograder_wrong_total,
+            ),
+            "revised_but_wrong": _breakdown_stats(
+                both_wrong_count,
+                total_evaluations=total_evaluations,
+                autograder_wrong_total=autograder_wrong_total,
+            ),
         },
         "breakdowns": {},
     }
 
-    def _resolve_display(column: str, value: str) -> str:
-        mapping = display_maps.get(column, {})
-        return mapping.get(value, value.title() if isinstance(value, str) else str(value))
-
-    def _attach_dimension_fields(
-        entry: Dict[str, object], dimension: str, label: str, display_label: str
-    ) -> None:
-        entry["label"] = label
-        entry["label_display"] = display_label
-        if dimension == "ground_truth":
-            entry["ground_truth"] = label
-            entry["ground_truth_display"] = display_label
-        elif dimension == "autograder_label":
-            entry["autograder_label"] = label
-            entry["autograder_label_display"] = display_label
-        elif dimension == "human_label":
-            entry["human_label"] = label
-            entry["human_label_display"] = display_label
-
     breakdowns: Dict[str, List[Dict[str, object]]] = {}
-    dimension_columns = (
-        ("ground_truth", ground_truth_column),
-        ("autograder_label", autograder_column),
-        ("human_label", human_column),
-    )
-
-    for dimension_key, column_name in dimension_columns:
+    for dimension_key, column_name in (
+        ("ground_truth", columns.ground_truth),
+        ("autograder_label", columns.autograder),
+        ("human_label", columns.human),
+    ):
         if not column_name or column_name not in normalized.columns:
             continue
 
-        entries: List[Dict[str, object]] = []
-        for label, _group in normalized.groupby(column_name, sort=True):
-            if pd.isna(label):
-                continue
-
-            label_mask = normalized[column_name] == label
-            label_total = int(label_mask.sum())
-            if label_total == 0:
-                continue
-
-            label_revision_count = int(revisions[label_mask].sum())
-            label_case_counts = {
-                case: int(mask[label_mask].sum()) for case, mask in case_masks.items()
-            }
-            label_autograder_wrong_total = int((autograder_wrong_mask & label_mask).sum())
-            label_corrected = label_case_counts.get("autograder_wrong_human_correct", 0)
-            label_both_wrong = label_case_counts.get("both_wrong", 0)
-            label_autograder_wrong_revised = label_corrected + label_both_wrong
-            label_autograder_wrong_unrevised = max(
-                0, label_autograder_wrong_total - label_autograder_wrong_revised
-            )
-
-            def _dimension_case_entry(
-                case_key: str, *, include_autograder_share: bool
-            ) -> Dict[str, object]:
-                count_value = label_case_counts.get(case_key, 0)
-                entry_case = {
-                    "count": count_value,
-                    "share_of_revisions": _format_rate(count_value, label_revision_count),
-                    "share_of_total": _format_rate(count_value, label_total),
-                }
-                if include_autograder_share:
-                    entry_case["share_of_autograder_wrong"] = _format_rate(
-                        count_value, label_autograder_wrong_total
-                    )
-                else:
-                    entry_case["share_of_autograder_wrong"] = None
-                return entry_case
-
-            def _dimension_breakdown_entry(count_value: int) -> Dict[str, object]:
-                return {
-                    "count": count_value,
-                    "share_of_autograder_wrong": _format_rate(
-                        count_value, label_autograder_wrong_total
-                    ),
-                    "share_of_total": _format_rate(count_value, label_total),
-                }
-
-            display_label = _resolve_display(column_name, label)
-            entry = {
-                "total_evaluations": label_total,
-                "revision_count": label_revision_count,
-                "revision_rate": _format_rate(label_revision_count, label_total),
-                "correct_revision_count": label_corrected,
-                "correct_revision_precision": _format_rate(
-                    label_corrected, label_revision_count
-                ),
-                "autograder_wrong_total": label_autograder_wrong_total,
-                "corrected_autograder_wrong": label_corrected,
-                "autograder_wrong_recall": _format_rate(
-                    label_corrected, label_autograder_wrong_total
-                ),
-                "cases": {
-                    "autograder_wrong_human_correct": _dimension_case_entry(
-                        "autograder_wrong_human_correct", include_autograder_share=True
-                    ),
-                    "autograder_correct_human_wrong": _dimension_case_entry(
-                        "autograder_correct_human_wrong", include_autograder_share=False
-                    ),
-                    "both_wrong": _dimension_case_entry(
-                        "both_wrong", include_autograder_share=True
-                    ),
-                },
-                "autograder_wrong_breakdown": {
-                    "corrected": _dimension_breakdown_entry(label_corrected),
-                    "not_revised": _dimension_breakdown_entry(
-                        label_autograder_wrong_unrevised
-                    ),
-                    "revised_but_wrong": _dimension_breakdown_entry(label_both_wrong),
-                },
-            }
-            _attach_dimension_fields(entry, dimension_key, label, display_label)
-            entries.append(entry)
-
+        entries = _dimension_breakdowns(
+            normalized=normalized,
+            column_name=column_name,
+            dimension_key=dimension_key,
+            display_maps=display_maps,
+            case_masks=case_masks,
+            revisions=revisions,
+            autograder_wrong_mask=autograder_wrong_mask,
+            total_evaluations=total_evaluations,
+        )
         if entries:
             breakdowns[dimension_key] = entries
 


### PR DESCRIPTION
## Summary
- introduce a ScaleColumns helper to centralize validation of grading scale columns
- refactor accuracy and revision metric calculations to share reusable helpers and reduce nested logic
- streamline dimension breakdown construction for clearer structure without changing computed values

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0e20c0ca88328a9b86902b138983e