### PR TITLE
Add generated_at timestamp to metrics JSON outputs

### DIFF
--- a/metrics/compute_accuracy.py
+++ b/metrics/compute_accuracy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import json
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -734,8 +735,10 @@ def write_metrics(metrics: Dict[str, object], output_path: Path) -> None:
     """Serialize ``metrics`` to ``output_path`` as pretty-printed JSON."""
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = dict(metrics)
+    payload["generated_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
     with output_path.open("w", encoding="utf-8") as fh:
-        json.dump(metrics, fh, indent=2)
+        json.dump(payload, fh, indent=2)
         fh.write("\n")
 
 

--- a/public/accuracy.json
+++ b/public/accuracy.json
@@ -18039,5 +18039,6 @@
       "autograder_accuracy": 1.0,
       "human_accuracy": 0.6667
     }
-  ]
+  ],
+  "generated_at": "2025-09-22T06:41:49+00:00"
 }

--- a/public/revision.json
+++ b/public/revision.json
@@ -2427,5 +2427,6 @@
       "ground_truth": "slightly unsatisfying",
       "ground_truth_display": "slightly unsatisfying"
     }
-  ]
+  ],
+  "generated_at": "2025-09-22T06:41:49+00:00"
 }

--- a/tests/test_compute_accuracy.py
+++ b/tests/test_compute_accuracy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from pathlib import Path
 import sys
 
@@ -286,4 +287,8 @@ def test_write_metrics_creates_expected_json(tmp_path: Path) -> None:
     assert output_path.exists()
     with output_path.open() as fh:
         data = json.load(fh)
-    assert data == payload
+    assert payload == {"summary": {"total": 3}}
+    assert data["summary"] == payload["summary"]
+    assert "generated_at" in data
+    # ``fromisoformat`` raises ``ValueError`` if the timestamp is not valid ISO-8601.
+    datetime.fromisoformat(data["generated_at"])


### PR DESCRIPTION
## Summary
- add a UTC `generated_at` timestamp when serialising metrics JSON files
- verify the timestamp is written without mutating the original payload
- regenerate the committed accuracy and revision reports with the new metadata

## Testing
- pytest
- python metrics/compute_accuracy.py --input data/toy_grading_dataset.csv --output public/accuracy.json --revision-output public/revision.json

------
https://chatgpt.com/codex/tasks/task_e_68d0ed57ea208328891302753a3a3989