### PR TITLE
Fix recall table case counts for repeated mistakes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1838,10 +1838,23 @@
         );
       }
 
-      function createCaseCell(entry, caseMeta, sliceConfig) {
+      function createCaseCell(entry, caseMeta, sliceConfig, options = {}) {
         const cell = document.createElement("td");
         const caseData = entry?.cases?.[caseMeta.key] || {};
-        const count = Number.isFinite(caseData.count) ? caseData.count : 0;
+        const rawCount = Number.isFinite(caseData.count) ? caseData.count : 0;
+        const factor =
+          Number.isFinite(options?.factor) && options.factor > 0
+            ? options.factor
+            : 1;
+        const countTransform =
+          typeof sliceConfig.caseCountValueTransform === "function"
+            ? sliceConfig.caseCountValueTransform
+            : typeof sliceConfig.countValueTransform === "function"
+            ? sliceConfig.countValueTransform
+            : null;
+        const count = countTransform
+          ? countTransform(rawCount, factor, entry, caseMeta)
+          : rawCount;
         const baseField = sliceConfig.caseBaseField || sliceConfig.countField;
         const baseCount = Number.isFinite(entry?.[baseField])
           ? entry[baseField]
@@ -2139,7 +2152,9 @@
         for (let index = 0; index < RECALL_MAX_CASE_COLUMNS; index += 1) {
           const caseMeta = sliceConfig.cases[index];
           if (caseMeta) {
-            row.appendChild(createCaseCell(entry, caseMeta, sliceConfig));
+            row.appendChild(
+              createCaseCell(entry, caseMeta, sliceConfig, { factor })
+            );
           } else {
             row.appendChild(createPrecisionPlaceholderCell());
           }


### PR DESCRIPTION
## Summary
- scale recall table case counts with the mistake repetition factor so they reflect evaluation totals
- allow future slice configs to customize case count transforms while keeping share values intact

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1bfb39cec8328850b9481bc5ed84f